### PR TITLE
tests: add some BrowserKit based tests and run them from the CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,4 +45,4 @@ jobs:
               php-symfony-mime
 
       - name: Run tests
-        run: phpunit tests
+        run: phpunit --testdox tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,15 @@ jobs:
           sudo systemctl restart nginx.service
           sudo mkdir -p /etc/private
           sudo cp /usr/share/plug-ugmm/www/PLUG/ldapconnection.inc.php.example /etc/private/ldapconnection.inc.php
-      - name: Load the front page
+
+      - name: Install testing dependencies
         run: |
-          curl --fail-with-body -L -D- http://localhost:8000/
-          curl --fail-with-body -L -D- -d 'plug_members_auth=1&username=bobtest&password=test432bob' http://localhost:8000/memberself
+          sudo apt-get install -y \
+              phpunit \
+              php-symfony-browser-kit \
+              php-symfony-css-selector \
+              php-symfony-http-client \
+              php-symfony-mime
+
+      - name: Run tests
+        run: phpunit tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,8 @@ jobs:
           sudo mkdir -p /etc/private
           sudo cp /usr/share/plug-ugmm/www/PLUG/ldapconnection.inc.php.example /etc/private/ldapconnection.inc.php
       - name: Set up fake sendmail
-        run: sudo ln -s $(pwd)/ci/fake-sendmail.sh /usr/sbin/sendmail
+        run: |
+          sudo cp ci/fake-sendmail.sh /usr/sbin/sendmail
 
       - name: Install testing dependencies
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,6 +34,8 @@ jobs:
           sudo systemctl restart nginx.service
           sudo mkdir -p /etc/private
           sudo cp /usr/share/plug-ugmm/www/PLUG/ldapconnection.inc.php.example /etc/private/ldapconnection.inc.php
+      - name: Set up fake sendmail
+        run: sudo ln -s $(pwd)/ci/fake-sendmail.sh /usr/sbin/sendmail
 
       - name: Install testing dependencies
         run: |

--- a/ci/fake-sendmail.sh
+++ b/ci/fake-sendmail.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+mbox=/tmp/ugmm-mbox
+
+echo "From no-reply@example.com" >> $mbox
+cat >> $mbox
+echo >> $mbox

--- a/ci/ugmm-nginx.conf
+++ b/ci/ugmm-nginx.conf
@@ -1,4 +1,4 @@
-map $request_uri $ugmm_script_name {
+map $uri $ugmm_script_name {
     default =404;
     /ajax.php              /ajax.php;
     /ctte-editmember       /ctte-editmember.php;

--- a/ci/user-bob.ldif
+++ b/ci/user-bob.ldif
@@ -11,7 +11,7 @@ uidNumber: 6969
 gidNumber: 6969
 homeDirectory: /home/bobtest
 userPassword: test432bob
-loginShell: /bin/sh
+loginShell: /bin/bash
 mail: bob@plug.org.au
 mailForward: bob@example.com
 givenName: Bob

--- a/ci/user-chair.ldif
+++ b/ci/user-chair.ldif
@@ -11,7 +11,7 @@ uidNumber: 6000
 gidNumber: 6000
 homeDirectory: /home/chair
 userPassword: chairpass
-loginShell: /bin/sh
+loginShell: /bin/bash
 mail: chair@plug.org.au
 mailForward: chair@example.com
 givenName: PLUG

--- a/tests/UGMMTest.php
+++ b/tests/UGMMTest.php
@@ -61,7 +61,7 @@ final class UGMMTest extends TestCase {
         $this->assertText($rows->eq(1), 'th', 'Unix User ID');
         $this->assertText($rows->eq(1), 'td', '6969');
         $this->assertText($rows->eq(2), 'th', 'Shell');
-        $this->assertText($rows->eq(2), 'td', '/bin/sh');
+        $this->assertText($rows->eq(2), 'td', '/bin/bash');
         $this->assertText($rows->eq(3), 'th', 'Account expires');
         $this->assertText($rows->eq(3), 'td', 'Wednesday, 31 December 1969');
     }
@@ -107,5 +107,29 @@ final class UGMMTest extends TestCase {
         $rows = $page->filter('table')->eq(0)->children();
         $this->assertText($rows->eq(2), 'th', 'Home Phone');
         $this->assertText($rows->eq(2), 'td', 'N/A');
+    }
+
+    public function testMemberEditForwarding() {
+        $client = new HttpBrowser();
+        $this->login($client, 'bobtest', 'test432bob');
+        $page = $client->clickLink('Change your e-mail forwarding');
+        $this->assertText($page, 'title', 'PLUG - Members Area - Editing Member Email Forwarding');
+
+        $data = $page->selectButton('Change')->form()->getValues();
+        $this->assertSame($data['email_forward'], 'bob@example.com');
+
+        // TODO: test posting the form
+    }
+
+    public function testMemberEditShell() {
+        $client = new HttpBrowser();
+        $this->login($client, 'bobtest', 'test432bob');
+        $page = $client->clickLink('Change your shell account settings');
+        $this->assertText($page, 'title', 'PLUG - Members Area - Editing Member Shell');
+
+        $data = $page->selectButton('Change Shell')->form()->getValues();
+        $this->assertSame($data['account_shell'], 'bash');
+
+        // TODO: test posting the form
     }
 }

--- a/tests/UGMMTest.php
+++ b/tests/UGMMTest.php
@@ -9,6 +9,7 @@ require_once '/usr/share/php/Symfony/Component/BrowserKit/autoload.php';
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\BrowserKit\HttpBrowser;
 
+$base_url = 'http://localhost:8000';
 
 final class UGMMTest extends TestCase {
 
@@ -18,7 +19,9 @@ final class UGMMTest extends TestCase {
     }
 
     public function login(HttpBrowser $client, string $username, string $password): Crawler {
-        $page = $client->request('GET', 'http://localhost:8000');
+        global $base_url;
+
+        $page = $client->request('GET', $base_url);
         $this->assertText($page, 'title', 'PLUG - Members Area - Login');
         return $client->submitForm('Log In', [
             'username' => $username,
@@ -157,5 +160,35 @@ final class UGMMTest extends TestCase {
             'newpassword' => 'test432bob',
             'newpasswordconfirm' => 'test432bob',
         ]);
+    }
+
+    public function testSignup() {
+        global $base_url;
+
+        $client = new HttpBrowser();
+        $page = $client->request('GET', $base_url);
+        $this->assertText($page, 'title', 'PLUG - Members Area - Login');
+        $page = $client->clickLink('Signup Form');
+        $this->assertText($page, 'title', 'PLUG - Members Area - Signup');
+
+        // TODO: make sure we have a unique user ID
+        $uid = sprintf('test%05d', rand(0, 99999));
+        $page = $client->submitForm('Signup', [
+            'givenName' => 'Test',
+            'sn' => 'Last-name',
+            'mail' => $uid . '@example.com',
+            'street' => '123 Fake St',
+            'homePhone' => '08 5550 1111',
+            'pager' => '08 5550 2222',
+            'mobile' => '08 5550 3333',
+            'uid' => $uid,
+            'password' => 'pass1234',
+            'vpassword' => 'pass1234',
+            'notes' => 'Sign up for testing',
+        ]);
+        $this->assertText($page, 'title', 'PLUG - Members Area - Signup complete');
+
+        // Verify that we can log in as the new user
+        $this->login($client, $uid, 'pass1234');
     }
 }

--- a/tests/UGMMTest.php
+++ b/tests/UGMMTest.php
@@ -42,6 +42,14 @@ final class UGMMTest extends TestCase {
         $this->assertText($page, '#errormessages strong', 'Incorrect Login.');
     }
 
+    public function testLogout() {
+        $client = new HttpBrowser();
+        $page = $this->login($client, 'bobtest', 'test432bob');
+        $this->assertText($page, 'title', 'PLUG - Members Area - Member Details');
+        $page = $client->clickLink('Logout');
+        $this->assertText($page, 'title', 'PLUG - Members Area - Login');
+    }
+
     public function testMemberselfInfo() {
         $client = new HttpBrowser();
         $page = $this->login($client, 'bobtest', 'test432bob');
@@ -190,5 +198,12 @@ final class UGMMTest extends TestCase {
 
         // Verify that we can log in as the new user
         $this->login($client, $uid, 'pass1234');
+    }
+
+    public function testCommitteeMembers() {
+        $client = new HttpBrowser();
+        $this->login($client, 'chair', 'chairpass');
+        $page = $client->clickLink('Committee');
+        $this->assertText($page, 'title', 'PLUG - Members Area - Membership List');
     }
 }

--- a/tests/UGMMTest.php
+++ b/tests/UGMMTest.php
@@ -17,28 +17,95 @@ final class UGMMTest extends TestCase {
         $this->assertSame($text, $value);
     }
 
-    public function testLoginSuccess() {
-        $client = new HttpBrowser();
+    public function login(HttpBrowser $client, string $username, string $password): Crawler {
         $page = $client->request('GET', 'http://localhost:8000');
         $this->assertText($page, 'title', 'PLUG - Members Area - Login');
-
-        $page = $client->submitForm('Log In', [
-            'username' => 'bobtest',
-            'password' => 'test432bob',
+        return $client->submitForm('Log In', [
+            'username' => $username,
+            'password' => $password,
         ]);
+    }
+
+    public function testLoginSuccess() {
+        $client = new HttpBrowser();
+        $page = $this->login($client, 'bobtest', 'test432bob');
         $this->assertText($page, 'title', 'PLUG - Members Area - Member Details');
     }
 
     public function testLoginFailure() {
         $client = new HttpBrowser();
-        $page = $client->request('GET', 'http://localhost:8000');
-        $this->assertText($page, 'title', 'PLUG - Members Area - Login');
-
-        $page = $client->submitForm('Log In', [
-            'username' => 'bobtest',
-            'password' => 'wrong',
-        ]);
+        $page = $this->login($client, 'bobtest', 'wrong');
         $this->assertText($page, 'title', 'PLUG - Members Area - Login');
         $this->assertText($page, '#errormessages strong', 'Incorrect Login.');
+    }
+
+    public function testMemberselfInfo() {
+        $client = new HttpBrowser();
+        $page = $this->login($client, 'bobtest', 'test432bob');
+
+        $rows = $page->filter('table')->eq(0)->children();
+        $this->assertText($rows->eq(0), 'th', 'E-mail Address');
+        $this->assertText($rows->eq(0), 'td', 'bob@plug.org.au');
+        $this->assertText($rows->eq(1), 'th', 'Postal Address');
+        $this->assertText($rows->eq(1), 'td', '42 Test Bvd, Nowheresville 6969');
+        $this->assertText($rows->eq(2), 'th', 'Home Phone');
+        $this->assertText($rows->eq(2), 'td', 'N/A');
+        $this->assertText($rows->eq(3), 'th', 'Work Phone');
+        $this->assertText($rows->eq(3), 'td', 'N/A');
+        $this->assertText($rows->eq(4), 'th', 'Mobile Phone');
+        $this->assertText($rows->eq(4), 'td', '0469 000000');
+
+        $rows = $page->filter('table')->eq(1)->children();
+        $this->assertText($rows->eq(0), 'th', 'Username');
+        $this->assertText($rows->eq(0), 'td', 'bobtest');
+        $this->assertText($rows->eq(1), 'th', 'Unix User ID');
+        $this->assertText($rows->eq(1), 'td', '6969');
+        $this->assertText($rows->eq(2), 'th', 'Shell');
+        $this->assertText($rows->eq(2), 'td', '/bin/sh');
+        $this->assertText($rows->eq(3), 'th', 'Account expires');
+        $this->assertText($rows->eq(3), 'td', 'Wednesday, 31 December 1969');
+    }
+
+    public function testMemberEditDetails() {
+        $client = new HttpBrowser();
+        $this->login($client, 'bobtest', 'test432bob');
+        $page = $client->clickLink('Edit your personal details');
+        $this->assertText($page, 'title', 'PLUG - Members Area - Editing Member Details');
+
+        $data = $page->selectButton('Update')->form()->getValues();
+        $this->assertSame($data['email_address'], 'bob@plug.org.au');
+        $this->assertSame($data['street_address'], '42 Test Bvd, Nowheresville 6969');
+        $this->assertSame($data['home_phone'], '');
+        $this->assertSame($data['work_phone'], '');
+        $this->assertSame($data['mobile_phone'], '0469 000000');
+
+        // Set home phone, and verify it has changed in the member details
+        $page = $client->submitForm('Update', [
+            'home_phone' => '08 5550 1234',
+        ]);
+        $this->assertText($page, 'title', 'PLUG - Members Area - Member Details');
+        $rows = $page->filter('table')->eq(0)->children();
+        $this->assertText($rows->eq(2), 'th', 'Home Phone');
+        $this->assertText($rows->eq(2), 'td', '08 5550 1234');
+
+        // And change it back
+        $page = $client->clickLink('Edit your personal details');
+        $data = $page->selectButton('Update')->form()->getValues();
+        $this->assertSame($data['home_phone'], '08 5550 1234');
+        $page = $client->submitForm('Update', [
+            'home_phone' => '',
+        ]);
+    }
+
+    public function testMemberEditDetailsCancel() {
+        $client = new HttpBrowser();
+        $this->login($client, 'bobtest', 'test432bob');
+        $page = $client->clickLink('Edit your personal details');
+        $page = $client->submitForm('Cancel', [
+            'home_phone' => '08 5550 1234',
+        ]);
+        $rows = $page->filter('table')->eq(0)->children();
+        $this->assertText($rows->eq(2), 'th', 'Home Phone');
+        $this->assertText($rows->eq(2), 'td', 'N/A');
     }
 }

--- a/tests/UGMMTest.php
+++ b/tests/UGMMTest.php
@@ -260,6 +260,7 @@ final class UGMMTest extends TestCase {
             'payment_ack' => '1',
         ]);
         $this->assertText($page, 'title', ' - Edit Member');
+        $this->assertText($page, '#successmessages li', 'Payment confirmation sent');
         $this->assertText($page, '#successmessages li', 'Payment processed');
     }
 

--- a/tests/UGMMTest.php
+++ b/tests/UGMMTest.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+use PHPUnit\Framework\TestCase;
+
+require_once '/usr/share/php/Symfony/Component/CssSelector/autoload.php';
+require_once '/usr/share/php/Symfony/Component/Mime/autoload.php';
+require_once '/usr/share/php/Symfony/Component/HttpClient/autoload.php';
+require_once '/usr/share/php/Symfony/Component/BrowserKit/autoload.php';
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\BrowserKit\HttpBrowser;
+
+
+final class UGMMTest extends TestCase {
+
+    private function assertText(Crawler $page, string $selector, string $value) {
+        $text = $page->filter($selector)->text();
+        $this->assertSame($text, $value);
+    }
+
+    public function testLoginSuccess() {
+        $client = new HttpBrowser();
+        $page = $client->request('GET', 'http://localhost:8000');
+        $this->assertText($page, 'title', 'PLUG - Members Area - Login');
+
+        $page = $client->submitForm('Log In', [
+            'username' => 'bobtest',
+            'password' => 'test432bob',
+        ]);
+        $this->assertText($page, 'title', 'PLUG - Members Area - Member Details');
+    }
+
+    public function testLoginFailure() {
+        $client = new HttpBrowser();
+        $page = $client->request('GET', 'http://localhost:8000');
+        $this->assertText($page, 'title', 'PLUG - Members Area - Login');
+
+        $page = $client->submitForm('Log In', [
+            'username' => 'bobtest',
+            'password' => 'wrong',
+        ]);
+        $this->assertText($page, 'title', 'PLUG - Members Area - Login');
+        $this->assertText($page, '#errormessages strong', 'Incorrect Login.');
+    }
+}

--- a/tests/UGMMTest.php
+++ b/tests/UGMMTest.php
@@ -132,4 +132,30 @@ final class UGMMTest extends TestCase {
 
         // TODO: test posting the form
     }
+
+    public function testMemberEditPassword() {
+        $client = new HttpBrowser();
+        $this->login($client, 'bobtest', 'test432bob');
+        $page = $client->clickLink('Change your PLUG password');
+        $this->assertText($page, 'title', 'PLUG - Members Area - Editing Member Password');
+
+        $page = $client->submitForm('Change Password', [
+            'current_password' => 'test432bob',
+            'newpassword' => 'newpassword123',
+            'newpasswordconfirm' => 'newpassword123',
+        ]);
+        $this->assertText($page, 'title', 'PLUG - Members Area - Member Details');
+        $this->assertText($page, '#successmessages li', 'Password changed');
+
+        // Try logging in with the new password, and change back
+        $client->getCookieJar()->clear();
+        $this->login($client, 'bobtest', 'newpassword123');
+        $this->assertText($page, 'title', 'PLUG - Members Area - Member Details');
+        $page = $client->clickLink('Change your PLUG password');
+        $page = $client->submitForm('Change Password', [
+            'current_password' => 'newpassword123',
+            'newpassword' => 'test432bob',
+            'newpasswordconfirm' => 'test432bob',
+        ]);
+    }
 }

--- a/www/PLUG/Members.class.php
+++ b/www/PLUG/Members.class.php
@@ -1510,7 +1510,7 @@ PLUG Membership Scripts";
 class PLUGFunction
 {
     // Validation function available globally
-    function is_valid_password($password)
+    static function is_valid_password($password)
     {
         $error = array();
         $newpassword = cleanpassword($password);
@@ -1531,7 +1531,7 @@ class PLUGFunction
 
     }
 
-    function check_password_strength($password)
+    static function check_password_strength($password)
     {
         $error = array();
         if(strlen($password) < 7)
@@ -1585,9 +1585,12 @@ function validatePassword($strPlainText, $strHash) {
     if (CRYPT_SHA512 != 1) {
         throw new Exception('Hashing mechanism not supported.');
     }
-
-    return (crypt($strPlainText, $strHash) == $strHash) ? true : false;
-
+    if (strtolower(substr($strHash, 0, 7)) == '{crypt}') {
+        $strHash = substr($strHash, 7);
+        return crypt($strPlainText, $strHash) == $strHash;
+    } else {
+        return $strPlainText == $strHash;
+    }
 }
 
 

--- a/www/PLUG/Members.class.php
+++ b/www/PLUG/Members.class.php
@@ -1242,7 +1242,7 @@ class Person {
         $cleanpayment['type'] = $payment['x-plug-paymentType'][0];
         $cleanpayment['years'] = $payment['x-plug-paymentYears'][0];
         $cleanpayment['dn'] = $payment['dn'];
-        $cleanpayment['description'] = $payment['x-plug-paymentDescription'][0];
+        $cleanpayment['description'] = isset($payment['x-plug-paymentDescription']) ? $payment['x-plug-paymentDescription'][0] : '';
         $cleanpayment['formatteddate'] = date('Y-m-d', strtotime($cleanpayment['date']));
         $cleanpayment['formattedamount'] = sprintf("$%.2f",$cleanpayment['amount']/100);
         $cleanpayment['formattedtype'] = $cleanpayment['type'] == FULL_TYPE ? "Full" : "Concession";
@@ -1350,7 +1350,7 @@ PLUG Membership Scripts";
                         COMMITTEE_EMAIL);
 
         // TODO: call send_user_email instead of doing it here
-        $headers .= "Reply-To: ".SCRIPTS_REPLYTO_EMAIL."\r\n";
+        $headers = "Reply-To: ".SCRIPTS_REPLYTO_EMAIL."\r\n";
         $headers .= "Return-Path: ".SCRIPTS_REPLYTO_EMAIL."\r\n";
         $headers .= "From: ".SCRIPTS_FROM_EMAIL."\r\n";
         $headers .= "Bcc: ".ADMIN_EMAIL."\r\n";

--- a/www/member-editpassword.php
+++ b/www/member-editpassword.php
@@ -21,8 +21,7 @@ require_once('./PLUG/session.inc.php');
     }        
     
     $memberdetails = $memberself->userarray();
-    // Remove {crypt} from front of password
-    $oldpasswordhash = substr($memberdetails['userPassword'], 7);
+    $oldpasswordhash = $memberdetails['userPassword'];
     if(isset($_POST['edit_selfpassword']) && ! validatePassword($_POST['current_password'], $oldpasswordhash))
         $error[] = "Old password does not match";
 

--- a/www/resetpassword.php
+++ b/www/resetpassword.php
@@ -28,8 +28,10 @@ if(isset($_POST['resetpassword_form']))
         if (isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] == "on") $reseturl .= "s";
         
         $reseturl .= "://";
-        $reseturl .= $_SERVER['HTTP_HOST']. $_SERVER['PHP_SELF']."?";
-        $reseturl .= "uid=".$member->uid();
+        $reseturl .= $_SERVER['HTTP_HOST'];
+        $parts = explode('?', $_SERVER['REQUEST_URI'], 2);
+        $reseturl .= $parts[0];
+        $reseturl .= "?uid=".$member->uid();
         $reseturl .= "&reset=".$member->create_hash();
         
         $name = $member->givenName();

--- a/www/signup.php
+++ b/www/signup.php
@@ -1,6 +1,8 @@
 <?php
 
 $ACCESS_LEVEL = 'all';
+$PAGETITLE = " - Signup";
+$TITLE = 'Signup';
 
 session_start();
 
@@ -70,7 +72,7 @@ if(isset($_POST['membersignup_form'])) {
             send_waitingpayment_email($member, $details);
             // TODO: Email user with instructions
             // TODO: Take them to a different page with payment details
-            display_page('signupcompleted.tpl');
+            display_page('signupcompleted.tpl', ' - Signup complete');
             exit();
             
         }
@@ -82,7 +84,7 @@ if(isset($_POST['membersignup_form'])) {
     }
 }
 
-display_page('signup.tpl', " - Signup");
+display_page('signup.tpl');
 
 
 function send_waitingpayment_email($member, $details)

--- a/www/templates/editmember.tpl
+++ b/www/templates/editmember.tpl
@@ -44,7 +44,7 @@
         <tr>
           <th>Postal Address</th>
 
-          <td><input name="street_address" value="{$member.street}"
+          <td><input name="street_address" value="{if isset($member.street)}{$member.street}{/if}"
           size="50" type="text"></td>
         </tr>
 
@@ -52,20 +52,20 @@
           <th>Home Phone</th>
 
           <td><input name="home_phone" size="20" type="text" value=
-          "{$member.homePhone}"></td>
+          "{if isset($member.homePhone)}{$member.homePhone}{/if}"></td>
         </tr>
 
         <tr>
           <th>Work Phone</th>
 
-          <td><input name="work_phone" value="{$member.pager}"
+          <td><input name="work_phone" value="{if isset($member.pager)}{$member.pager}{/if}"
           size="20" type="text"></td>
         </tr>
 
         <tr>
           <th>Mobile Phone</th>
 
-          <td><input name="mobile_phone" value="{$member.mobile}"
+          <td><input name="mobile_phone" value="{if isset($member.mobile)}{$member.mobile}{/if}"
           size="20" type="text"></td>
         </tr>
 

--- a/www/templates/editselfdetails.tpl
+++ b/www/templates/editselfdetails.tpl
@@ -31,7 +31,7 @@
       <tr>
         <th>Home Phone</th>
 
-        <td><input type="text" name="home_phone" size="20" value="{$member.homePhone}"></td>
+        <td><input type="text" name="home_phone" size="20" value="{if isset($member.homePhone)}{$member.homePhone}{/if}"></td>
       </tr>
 
       <tr>
@@ -45,7 +45,7 @@
         <th>Mobile Phone</th>
 
         <td><input type="text" name="mobile_phone" value=
-        "{$member.mobile}" size="20"></td>
+        "{if isset($member.mobile)}{$member.mobile}{/if}" size="20"></td>
       </tr>
     </table><input type="submit" name="go_go_button" value=
     "Update"> <input type="submit" name="oops_button" value=

--- a/www/templates/memberself.tpl
+++ b/www/templates/memberself.tpl
@@ -83,13 +83,10 @@ missing any emails.
 
 </p>
 <p>
-<ul><li><a href="{$submenuitems.home.editselfshell.link}">Change your shell account settings<a></ul></p>
+<ul><li><a href="{$submenuitems.home.editselfshell.link}">Change your shell account settings</a></ul></p>
 <h3><a name="password"></a>Your password</h3>
 Your PLUG password is used to access the members area of the website and login
 to PLUG machines. It is not associated with your PLUG mailing list
 subscriptions in any way.
 <p>
 <ul><li><a href="{$submenuitems.home.editselfpassword.link}">Change your PLUG password</a></ul></p>
-</td>
-</tr>
-</table>

--- a/www/templates/newmember.tpl
+++ b/www/templates/newmember.tpl
@@ -16,27 +16,27 @@
         <tr>
           <th>First Name *</th>
 
-          <td><input name="first_name" value="{$member.givenName}"
+          <td><input name="first_name" value="{if isset($member.givenName)}{$member.givenName}{/if}"
           size="30" type="text"></td>
         </tr>
 
         <tr>
           <th>Last Name</th>
 
-          <td><input name="last_name" value="{$member.sn}" size=
+          <td><input name="last_name" value="{if isset($member.sn)}{$member.sn}{/if}" size=
           "30" type="text"></td>
         </tr>
 
         <tr>
           <th>E-mail Address *</th>
 
-          <td><input name="email_address" value="{$member.mail}" size="30" type="text"></td>
+          <td><input name="email_address" value="{if isset($member.mail)}{$member.mail}{/if}" size="30" type="text"></td>
         </tr>
 
         <tr>
           <th>Postal Address *</th>
 
-          <td><input name="street_address" value="{$member.street}"
+          <td><input name="street_address" value="{if isset($member.street)}{$member.street}{/if}"
           size="50" type="text"></td>
         </tr>
 
@@ -44,33 +44,33 @@
           <th>Home Phone</th>
 
           <td><input name="home_phone" size="20" type="text" value=
-          "{$member.homePhone}"></td>
+          "{if isset($member.homePhone)}{$member.homePhone}{/if}"></td>
         </tr>
 
         <tr>
           <th>Work Phone</th>
 
-          <td><input name="work_phone" value="{$member.pager}"
+          <td><input name="work_phone" value="{if isset($member.pager)}{$member.pager}{/if}"
           size="20" type="text"></td>
         </tr>
 
         <tr>
           <th>Mobile Phone</th>
 
-          <td><input name="mobile_phone" value="{$member.mobile}"
+          <td><input name="mobile_phone" value="{if isset($member.mobile)}{$member.mobile}{/if}"
           size="20" type="text"></td>
         </tr>
         <tr>
           <th>Username *</th>
 
-          <td><input name="uid" value="{$member.uid}"
+          <td><input name="uid" value="{if isset($member.uid)}{$member.uid}{/if}"
           size="30" type="text"></td>
         </tr>  
 
         <tr>
           <th>Password *</th>
 
-          <td><input name="password" value="{$member.password}"
+          <td><input name="password" value="{if isset($member.password)}{$member.password}{/if}"
            type="password"></td>
         </tr>  
         
@@ -86,7 +86,7 @@
 
           <td>
           <textarea name="notes" rows="3" cols="40">
-{$member.description}
+{if isset($member.description)}{$member.description}{/if}
 </textarea></td>
         </tr>
       </tbody>


### PR DESCRIPTION
This builds on #21, adding some tests written with [BrowserKit](https://symfony.com/doc/current/components/browser_kit.html) and [PHPUnit](https://phpunit.de/) to replace the curl invocations.

This handles cookies, following links, form submissions, etc for us, and provides helpers for inspecting portions of the page content. I've started with the login form, but ideally we'd have a test for each page and form submission. We should also be able to peak behind the covers and check that the LDAP directory has been updated correctly too.

For pages depending on email, I install a script as `/usr/sbin/sendmail` that dumps the messages to `/tmp/ugmm-mbox`. In particular this is used to test the reset password workflow.