### PR TITLE
Get rid of jquery

### DIFF
--- a/ci/ugmm-nginx.conf
+++ b/ci/ugmm-nginx.conf
@@ -24,10 +24,6 @@ server {
         return 302 /memberself;
     }
 
-    location ^~ /javascript {
-        alias /usr/share/javascript;
-    }
-
     location ~ \.(css|gif|png|ico)$ {
     }
 

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: http://www.plug.org.au/projects/ugmm/
 
 Package: plug-ugmm
 Architecture: all
-Depends: ${misc:Depends}, smarty4, php, nginx | apache2-bin, libjs-jquery-ui, php-net-ldap2
+Depends: ${misc:Depends}, smarty4, php, nginx | apache2-bin, php-net-ldap2
 Recommends: php-fpm
 Description: PLUG User Group Members Management
  PHP Frontend to LDAP backend for managing a user group of members

--- a/extras/examples/apache/plug-ugmm.conf
+++ b/extras/examples/apache/plug-ugmm.conf
@@ -13,8 +13,3 @@
         RewriteCond "%{REQUEST_FILENAME}" !-d
         RewriteRule (.*) $1.php [L]
     </Directory>
-
-    Alias /javascript /usr/share/javascript
-    <Directory /usr/share/javascript>
-        Require all granted
-    </Directory>

--- a/extras/examples/apache/plug-ugmm.section.conf
+++ b/extras/examples/apache/plug-ugmm.section.conf
@@ -9,8 +9,3 @@
         RewriteCond "%{REQUEST_FILENAME}" !-d
         RewriteRule (.*) $1.php [L]
     </Directory>
-
-    Alias /javascript /usr/share/javascript
-    <Directory /usr/share/javascript>
-        Require all granted
-    </Directory>

--- a/extras/examples/nginx/plug-ugmm.conf
+++ b/extras/examples/nginx/plug-ugmm.conf
@@ -12,11 +12,6 @@
         rewrite .* /memberself permanent;
     }
 
-    # Forced prefix for JavaScript files installed from system packages
-    location ^~ /javascript {
-        alias /usr/share/javascript;
-    }
-
     # Paths without an extension after the first component are handled by
     # PHP files
     location ~ ^/[^./]+(/|$) {

--- a/extras/examples/nginx/plug-ugmm.section.conf
+++ b/extras/examples/nginx/plug-ugmm.section.conf
@@ -7,11 +7,6 @@
         rewrite .* /ugmm/memberself permanent;
     }
 
-    # Forced prefix for JavaScript files installed from system packages
-    location ^~ /javascript {
-        alias /usr/share/javascript;
-    }
-
     # Paths without an extension after the first component are handled by
     # PHP files
     location ~ ^/ugmm/[^./]+(/|$) {

--- a/www/style.css
+++ b/www/style.css
@@ -184,9 +184,23 @@ form#membersignup button:hover {
     height: 11px;
     float: right;
     display: none;
+    opacity: 0%;
+    transition: opacity 400ms ease-in, display 400ms allow-discrete;
 }
 
 #uidcheck {
     display: none;
+    opacity: 0%;
+    transition: opacity 400ms ease-in, display 400ms allow-discrete;
 }
 
+.fade-in {
+    display: block !important;
+    opacity: 100% !important;
+}
+
+@starting-style {
+    .fade-in {
+        opacity: 0% !important;
+    }
+}

--- a/www/templates/header.tpl
+++ b/www/templates/header.tpl
@@ -9,12 +9,6 @@
 <link rel="stylesheet" type="text/css" href="style.css" id="plug_css" />
 <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
 
-<link type="text/css" href="/javascript/jquery-ui/css/smoothness/jquery-ui.css" rel="stylesheet" />
-
-<script language="javascript" type="text/javascript" src="/javascript/jquery/jquery.js"></script>
-
-<script language="javascript" type="text/javascript" src="/javascript/jquery-ui/jquery-ui.js"></script>
-
 
 <body>
 <div id="page" class="content">

--- a/www/templates/signup.tpl
+++ b/www/templates/signup.tpl
@@ -1,17 +1,38 @@
 {literal}
 <script type="text/javascript">
-$(document).ready(function () {
-    $('#uid').blur(function(){
-        $("#uidcheckLoading").show();
-        $.post("ajax.php", {
-            uid: $('#uid').val(),
-            ajax: 'checkusername'},
-            function(response){
-                $('#uidcheckLoading').fadeOut();
-                $('#uidcheck').html(unescape(response)).show();
+document.addEventListener('DOMContentLoaded', () => {
+    let uid = document.getElementById('uid');
+    let check = document.getElementById('uidcheck');
+    let loading = document.getElementById('uidcheckLoading');
+    let controller;
+
+    uid.addEventListener('blur', () => {
+        loading.classList.add('fade-in');
+        if (controller)
+            controller.abort();
+        controller = new AbortController();
+        (async (signal) => {
+            try {
+                response = await fetch('ajax.php', {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/x-www-form-urlencoded",
+                    },
+                    body: new URLSearchParams({
+                        ajax: 'checkusername', uid: uid.value}),
+                    signal: signal,
+                });
+                if (response.ok) {
+                    check.classList.add('fade-in');
+                    check.innerHTML = await response.text();
+                }
+            } catch (err) {
+                console.log(err);
+            } finally {
+                loading.classList.remove('fade-in');
+                controller = null;
             }
-        );
-        return false;
+        })(controller.signal);
     });
 });
 </script>


### PR DESCRIPTION
Improvements to CSS and JavaScript make jQuery mostly redundant. This PR replaces the jQuery usage with standard JS and CSS.

While it is a bit more verbose, it's a lot smaller if you consider the removal of all the jquery JS and CSS. It also adds support for cancellation of the AJAX call if the check is invoked a second time.