### PR TITLE
Update the rfc2307bis schema

### DIFF
--- a/ci/basic-structure.ldif
+++ b/ci/basic-structure.ldif
@@ -22,7 +22,7 @@ dn: cn=maxUid,ou=Users,dc=plug,dc=org,dc=au
 objectClass: namedObject
 objectClass: extensibleObject
 objectClass: top
-uidNumber: 10000
+uidNumber: 10002
 cn: maxUid
 x-plug-paymentID: 1
 

--- a/ci/rfc2307bis.ldif
+++ b/ci/rfc2307bis.ldif
@@ -1,543 +1,262 @@
-#
-################################################################################
-#
 dn: cn=rfc2307bis,cn=schema,cn=config
 objectClass: olcSchemaConfig
 cn: rfc2307bis
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.2
-  NAME 'gecos'
+###
+# Extracted from: http://tools.ietf.org/html/draft-howard-rfc2307bis-02
+###
+# Builtin
+#attributeType ( 1.3.6.1.1.1.1.0 NAME 'uidNumber'
+#    DESC 'An integer uniquely identifying a user in an
+#          administrative domain'
+#    EQUALITY integerMatch
+#    ORDERING integerOrderingMatch
+#    SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+#    SINGLE-VALUE )
+# Builtin
+#attributeType ( 1.3.6.1.1.1.1.1 NAME 'gidNumber'
+#    DESC 'An integer uniquely identifying a group in an
+#          administrative domain'
+#    EQUALITY integerMatch
+#    ORDERING integerOrderingMatch
+#    SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+#    SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.2 NAME 'gecos'
   DESC 'The GECOS field; the common name'
-  EQUALITY caseIgnoreIA5Match
-  SUBSTR caseIgnoreIA5SubstringsMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
-  SINGLE-VALUE
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.3
-  NAME 'homeDirectory'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.3 NAME 'homeDirectory'
   DESC 'The absolute path to the home directory'
   EQUALITY caseExactIA5Match
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
-  SINGLE-VALUE
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.4
-  NAME 'loginShell'
+  SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.4 NAME 'loginShell'
   DESC 'The path to the login shell'
   EQUALITY caseExactIA5Match
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
-  SINGLE-VALUE
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.5
-  NAME 'shadowLastChange'
+  SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.5 NAME 'shadowLastChange'
   EQUALITY integerMatch
+  ORDERING integerOrderingMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-  SINGLE-VALUE
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.6
-  NAME 'shadowMin'
+  SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.6 NAME 'shadowMin'
   EQUALITY integerMatch
+  ORDERING integerOrderingMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-  SINGLE-VALUE
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.7
-  NAME 'shadowMax'
+  SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.7 NAME 'shadowMax'
   EQUALITY integerMatch
+  ORDERING integerOrderingMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-  SINGLE-VALUE
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.8
-  NAME 'shadowWarning'
+  SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.8 NAME 'shadowWarning'
   EQUALITY integerMatch
+  ORDERING integerOrderingMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-  SINGLE-VALUE
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.9
-  NAME 'shadowInactive'
+  SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.9 NAME 'shadowInactive'
   EQUALITY integerMatch
+  ORDERING integerOrderingMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-  SINGLE-VALUE
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.10
-  NAME 'shadowExpire'
+  SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.10 NAME 'shadowExpire'
   EQUALITY integerMatch
+  ORDERING integerOrderingMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-  SINGLE-VALUE
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.11
-  NAME 'shadowFlag'
+  SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.11 NAME 'shadowFlag'
   EQUALITY integerMatch
+  ORDERING integerOrderingMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-  SINGLE-VALUE
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.12
-  NAME 'memberUid'
-  EQUALITY caseExactIA5Match
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.13
-  NAME 'memberNisNetgroup'
-  EQUALITY caseExactIA5Match
-  SUBSTR caseExactIA5SubstringsMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.14
-  NAME 'nisNetgroupTriple'
+  SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.12 NAME 'memberUid'
+  EQUALITY caseExactMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.13 NAME 'memberNisNetgroup'
+  EQUALITY caseExactMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.14 NAME 'nisNetgroupTriple'
   DESC 'Netgroup triple'
-  EQUALITY caseIgnoreIA5Match
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.15
-  NAME 'ipServicePort'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.15 NAME 'ipServicePort'
   DESC 'Service port number'
   EQUALITY integerMatch
+  ORDERING integerOrderingMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-  SINGLE-VALUE
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.16
-  NAME 'ipServiceProtocol'
+  SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.16 NAME 'ipServiceProtocol'
   DESC 'Service protocol name'
-  SUP name
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.17
-  NAME 'ipProtocolNumber'
+  EQUALITY caseIgnoreMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.17 NAME 'ipProtocolNumber'
   DESC 'IP protocol number'
   EQUALITY integerMatch
+  ORDERING integerOrderingMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-  SINGLE-VALUE
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.18
-  NAME 'oncRpcNumber'
+  SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.18 NAME 'oncRpcNumber'
   DESC 'ONC RPC number'
   EQUALITY integerMatch
+  ORDERING integerOrderingMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-  SINGLE-VALUE
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.19
-  NAME 'ipHostNumber'
-  DESC 'IPv4 addresses as a dotted decimal omitting leading zeros or IPv6 addresses as defined in RFC2373'
-  SUP name
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.20
-  NAME 'ipNetworkNumber'
-  DESC 'IP network as a dotted decimal, eg. 192.168, omitting leading zeros'
-  SUP name
-  SINGLE-VALUE
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.21
-  NAME 'ipNetmaskNumber'
-  DESC 'IP netmask as a dotted decimal, eg. 255.255.255.0, omitting leading zeros'
+  SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.19 NAME 'ipHostNumber'
+  DESC 'IPv4 addresses as a dotted decimal omitting leading
+  zeros or IPv6 addresses as defined in RFC2373'
+  EQUALITY caseIgnoreIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.20 NAME 'ipNetworkNumber'
+  DESC 'IP network omitting leading zeros, eg. 192.168'
   EQUALITY caseIgnoreIA5Match
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
-  SINGLE-VALUE
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.22
-  NAME 'macAddress'
-  DESC 'MAC address in maximal, colon separated hex notation, eg. 00:00:92:90:ee:e2'
+  SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.21 NAME 'ipNetmaskNumber'
+  DESC 'IP netmask omitting leading zeros, eg. 255.255.255.0'
   EQUALITY caseIgnoreIA5Match
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.23
-  NAME 'bootParameter'
+  SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.22 NAME 'macAddress'
+  DESC 'MAC address in maximal, colon separated hex
+  notation, eg. 00:00:92:90:ee:e2'
+  EQUALITY caseIgnoreIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.23 NAME 'bootParameter'
   DESC 'rpc.bootparamd parameter'
   EQUALITY caseExactIA5Match
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.24
-  NAME 'bootFile'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.24 NAME 'bootFile'
   DESC 'Boot image name'
   EQUALITY caseExactIA5Match
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.26
-  NAME 'nisMapName'
-  DESC 'Name of a A generic NIS map'
-  SUP name
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.27
-  NAME 'nisMapEntry'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.26 NAME 'nisMapName'
+  DESC 'Name of a generic NIS map'
+  EQUALITY caseIgnoreMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{64} )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.27 NAME 'nisMapEntry'
   DESC 'A generic NIS entry'
-  EQUALITY caseExactIA5Match
-  SUBSTR caseExactIA5SubstringsMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
-  SINGLE-VALUE
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.28
-  NAME 'nisPublicKey'
+  EQUALITY caseExactMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{1024}
+  SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.28 NAME 'nisPublicKey'
   DESC 'NIS public key'
   EQUALITY octetStringMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
-  SINGLE-VALUE
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.29
-  NAME 'nisSecretKey'
+  SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.29 NAME 'nisSecretKey'
   DESC 'NIS secret key'
   EQUALITY octetStringMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
-  SINGLE-VALUE
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.30
-  NAME 'nisDomain'
+  SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.30 NAME 'nisDomain'
   DESC 'NIS domain'
   EQUALITY caseIgnoreIA5Match
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.31
-  NAME 'automountMapName'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{256} )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.31 NAME 'automountMapName'
   DESC 'automount Map Name'
-  EQUALITY caseExactIA5Match
-  SUBSTR caseExactIA5SubstringsMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
-  SINGLE-VALUE
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.32
-  NAME 'automountKey'
+  EQUALITY caseExactMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.32 NAME 'automountKey'
   DESC 'Automount Key value'
-  EQUALITY caseExactIA5Match
-  SUBSTR caseExactIA5SubstringsMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
-  SINGLE-VALUE
-  )
-#
-################################################################################
-#
-olcAttributeTypes: (
-  1.3.6.1.1.1.1.33
-  NAME 'automountInformation'
+  EQUALITY caseExactMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  SINGLE-VALUE )
+olcAttributeTypes: ( 1.3.6.1.1.1.1.33 NAME 'automountInformation'
   DESC 'Automount information'
-  EQUALITY caseExactIA5Match
-  SUBSTR caseExactIA5SubstringsMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
-  SINGLE-VALUE
-  )
-#
-################################################################################
-#
-olcObjectClasses: (
-  1.3.6.1.1.1.2.0
-  NAME 'posixAccount'
+  EQUALITY caseExactMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  SINGLE-VALUE )
+olcObjectClasses: ( 1.3.6.1.1.1.2.0 NAME 'posixAccount' SUP top AUXILIARY
   DESC 'Abstraction of an account with POSIX attributes'
-  SUP top
-  AUXILIARY
   MUST ( cn $ uid $ uidNumber $ gidNumber $ homeDirectory )
-  MAY ( userPassword $ loginShell $ gecos $ description )
-  )
-#
-################################################################################
-#
-olcObjectClasses: (
-  1.3.6.1.1.1.2.1
-  NAME 'shadowAccount'
+  MAY ( userPassword $ loginShell $ gecos $
+  description ) )
+olcObjectClasses: ( 1.3.6.1.1.1.2.1 NAME 'shadowAccount' SUP top AUXILIARY
   DESC 'Additional attributes for shadow passwords'
-  SUP top
-  AUXILIARY
   MUST uid
-  MAY ( userPassword $ description $ shadowLastChange $ shadowMin $ shadowMax $ shadowWarning $ shadowInactive $ shadowExpire $ shadowFlag )
-  )
-#
-################################################################################
-#
-olcObjectClasses: (
-  1.3.6.1.1.1.2.2
-  NAME 'posixGroup'
+  MAY ( userPassword $ description $
+  shadowLastChange $ shadowMin $ shadowMax $
+  shadowWarning $ shadowInactive $
+  shadowExpire $ shadowFlag ) )
+olcObjectClasses: ( 1.3.6.1.1.1.2.2 NAME 'posixGroup' SUP top AUXILIARY
   DESC 'Abstraction of a group of accounts'
-  SUP top
-  AUXILIARY
   MUST gidNumber
-  MAY ( userPassword $ memberUid $ description )
-  )
-#
-################################################################################
-#
-olcObjectClasses: (
-  1.3.6.1.1.1.2.3
-  NAME 'ipService'
-  DESC 'Abstraction an Internet Protocol service. Maps an IP port and protocol (such as tcp or udp) to one or more names; the distinguished value of the cn attribute denotes the services canonical name'
-  SUP top
-  STRUCTURAL
+  MAY ( userPassword $ memberUid $
+  description ) )
+olcObjectClasses: ( 1.3.6.1.1.1.2.3 NAME 'ipService' SUP top STRUCTURAL
+  DESC 'Abstraction an Internet Protocol service.
+  Maps an IP port and protocol (such as tcp or udp)
+  to one or more names; the distinguished value of
+  the cn attribute denotes the services canonical
+  name'
   MUST ( cn $ ipServicePort $ ipServiceProtocol )
-  MAY description
-  )
-#
-################################################################################
-#
-olcObjectClasses: (
-  1.3.6.1.1.1.2.4
-  NAME 'ipProtocol'
-  DESC 'Abstraction of an IP protocol. Maps a protocol number to one or more names. The distinguished value of the cn attribute denotes the protocols canonical name'
-  SUP top
-  STRUCTURAL
+  MAY description )
+olcObjectClasses: ( 1.3.6.1.1.1.2.4 NAME 'ipProtocol' SUP top STRUCTURAL
+  DESC 'Abstraction of an IP protocol. Maps a protocol number
+  to one or more names. The distinguished value of the cn
+  attribute denotes the protocol canonical name'
   MUST ( cn $ ipProtocolNumber )
-  MAY description
-  )
-#
-################################################################################
-#
-olcObjectClasses: (
-  1.3.6.1.1.1.2.5
-  NAME 'oncRpc'
-  DESC 'Abstraction of an Open Network Computing (ONC) [RFC1057] Remote Procedure Call (RPC) binding. This class maps an ONC RPC number to a name. The distinguished value of the cn attribute denotes the RPC services canonical name'
-  SUP top
-  STRUCTURAL
+  MAY description )
+olcObjectClasses: ( 1.3.6.1.1.1.2.5 NAME 'oncRpc' SUP top STRUCTURAL
+  DESC 'Abstraction of an Open Network Computing (ONC)
+  [RFC1057] Remote Procedure Call (RPC) binding.
+  This class maps an ONC RPC number to a name.
+  The distinguished value of the cn attribute denotes
+  the RPC service canonical name'
   MUST ( cn $ oncRpcNumber )
-  MAY description
-  )
-#
-################################################################################
-#
-olcObjectClasses: (
-  1.3.6.1.1.1.2.6
-  NAME 'ipHost'
-  DESC 'Abstraction of a host, an IP device. The distinguished value of the cn attribute denotes the hosts canonical name. Device SHOULD be used as a structural class'
-  SUP top
-  AUXILIARY
+  MAY description )
+olcObjectClasses: ( 1.3.6.1.1.1.2.6 NAME 'ipHost' SUP top AUXILIARY
+  DESC 'Abstraction of a host, an IP device. The distinguished
+  value of the cn attribute denotes the hosts canonical
+  name. Device SHOULD be used as a structural class'
   MUST ( cn $ ipHostNumber )
-  MAY ( userPassword $ l $ description $ manager )
-  )
-#
-################################################################################
-#
-olcObjectClasses: (
-  1.3.6.1.1.1.2.7
-  NAME 'ipNetwork'
-  DESC 'Abstraction of a network. The distinguished value of the cn attribute denotes the networks canonical name'
-  SUP top
-  STRUCTURAL
+  MAY ( userPassword $ l $ description $
+  manager ) )
+olcObjectClasses: ( 1.3.6.1.1.1.2.7 NAME 'ipNetwork' SUP top STRUCTURAL
+  DESC 'Abstraction of a network. The distinguished value of
+  the cn attribute denotes the network canonical name'
   MUST ipNetworkNumber
-  MAY ( cn $ ipNetmaskNumber $ l $ description $ manager )
-  )
-#
-################################################################################
-#
-olcObjectClasses: (
-  1.3.6.1.1.1.2.8
-  NAME 'nisNetgroup'
-  DESC 'Abstraction of a netgroup. May refer to other netgroups'
-  SUP top
-  STRUCTURAL
+  MAY ( cn $ ipNetmaskNumber $ l $ description $ manager ) )
+olcObjectClasses: ( 1.3.6.1.1.1.2.8 NAME 'nisNetgroup' SUP top STRUCTURAL
+  DESC 'Abstraction of a netgroup. May refer to other
+  netgroups'
   MUST cn
-  MAY ( nisNetgroupTriple $ memberNisNetgroup $ description )
-  )
-#
-################################################################################
-#
-olcObjectClasses: (
-  1.3.6.1.1.1.2.9
-  NAME 'nisMap'
+  MAY ( nisNetgroupTriple $ memberNisNetgroup $ description ) )
+olcObjectClasses: ( 1.3.6.1.1.1.2.9 NAME 'nisMap' SUP top STRUCTURAL
   DESC 'A generic abstraction of a NIS map'
-  SUP top
-  STRUCTURAL
   MUST nisMapName
-  MAY description
-  )
-#
-################################################################################
-#
-olcObjectClasses: (
-  1.3.6.1.1.1.2.10
-  NAME 'nisObject'
+  MAY description )
+olcObjectClasses: ( 1.3.6.1.1.1.2.10 NAME 'nisObject' SUP top STRUCTURAL
   DESC 'An entry in a NIS map'
-  SUP top
-  STRUCTURAL
-  MUST ( cn $ nisMapEntry $ nisMapName )
-  MAY description
-  )
-#
-################################################################################
-#
-olcObjectClasses: (
-  1.3.6.1.1.1.2.11
-  NAME 'ieee802Device'
-  DESC 'A device with a MAC address; device SHOULD be used as a structural class'
-  SUP top
-  AUXILIARY
-  MAY macAddress
-  )
-#
-################################################################################
-#
-olcObjectClasses: (
-  1.3.6.1.1.1.2.12
-  NAME 'bootableDevice'
-  DESC 'A device with boot parameters; device SHOULD be used as a structural class'
-  SUP top
-  AUXILIARY
-  MAY ( bootFile $ bootParameter )
-  )
-#
-################################################################################
-#
-olcObjectClasses: (
-  1.3.6.1.1.1.2.14
-  NAME 'nisKeyObject'
+  MUST ( cn $ nisMapEntry $ nisMapName ) )
+olcObjectClasses: ( 1.3.6.1.1.1.2.11 NAME 'ieee802Device' SUP top AUXILIARY
+  DESC 'A device with a MAC address; device SHOULD be
+  used as a structural class'
+  MAY macAddress )
+olcObjectClasses: ( 1.3.6.1.1.1.2.12 NAME 'bootableDevice' SUP top AUXILIARY
+  DESC 'A device with boot parameters; device SHOULD be
+  used as a structural class'
+  MAY ( bootFile $ bootParameter ) )
+olcObjectClasses: ( 1.3.6.1.1.1.2.14 NAME 'nisKeyObject' SUP top AUXILIARY
   DESC 'An object with a public and secret key'
-  SUP top
-  AUXILIARY
   MUST ( cn $ nisPublicKey $ nisSecretKey )
-  MAY ( uidNumber $ description )
-  )
-#
-################################################################################
-#
-olcObjectClasses: (
-  1.3.6.1.1.1.2.15
-  NAME 'nisDomainObject'
+  MAY ( uidNumber $ description ) )
+olcObjectClasses: ( 1.3.6.1.1.1.2.15 NAME 'nisDomainObject' SUP top AUXILIARY
   DESC 'Associates a NIS domain with a naming context'
-  SUP top
-  AUXILIARY
-  MUST nisDomain
-  )
-#
-################################################################################
-#
-olcObjectClasses: (
-  1.3.6.1.1.1.2.16
-  NAME 'automountMap'
-  SUP top
-  STRUCTURAL
+  MUST nisDomain )
+olcObjectClasses: ( 1.3.6.1.1.1.2.16 NAME 'automountMap' SUP top STRUCTURAL
   MUST ( automountMapName )
-  MAY description
-  )
-#
-################################################################################
-#
-olcObjectClasses: (
-  1.3.6.1.1.1.2.17
-  NAME 'automount'
+  MAY description )
+olcObjectClasses: ( 1.3.6.1.1.1.2.17 NAME 'automount' SUP top STRUCTURAL
   DESC 'Automount information'
-  SUP top
-  STRUCTURAL
   MUST ( automountKey $ automountInformation )
-  MAY description
-  )
-#
-################################################################################
-#
-olcObjectClasses: (
-  1.3.6.1.4.1.5322.13.1.1
-  NAME 'namedObject'
-  SUP top
-  STRUCTURAL
-  MAY cn
-  )
-#
-################################################################################
-#
+  MAY description )
+olcObjectClasses: ( 1.3.6.1.1.1.2.18 NAME 'groupOfMembers' SUP top STRUCTURAL
+  DESC 'A group with members (DNs)'
+  MUST cn
+  MAY ( businessCategory $ seeAlso $ owner $ ou $ o $
+  description $ member ) )

--- a/ci/setup-slapd.sh
+++ b/ci/setup-slapd.sh
@@ -34,6 +34,7 @@ dpkg-reconfigure slapd
 ldapadd -H ldapi:// -Y EXTERNAL -f $curdir/load-memberof.ldif
 
 # Add UGMM's plugpen schema
+ldapadd -H ldapi:// -Y EXTERNAL -f /etc/ldap/schema/namedobject.ldif
 ldapadd -H ldapi:// -Y EXTERNAL -f $curdir/../plugpen.ldif
 
 # Load basic structure

--- a/ci/user-bob.ldif
+++ b/ci/user-bob.ldif
@@ -1,4 +1,4 @@
-dn: uidNumber=6969,ou=Users,dc=plug,dc=org,dc=au
+dn: uidNumber=10001,ou=Users,dc=plug,dc=org,dc=au
 objectClass: top
 objectClass: person
 objectClass: posixAccount
@@ -7,8 +7,8 @@ objectClass: shadowAccount
 objectClass: mailForwardingAccount
 uid: bobtest
 displayName: Bob Test
-uidNumber: 6969
-gidNumber: 6969
+uidNumber: 10001
+gidNumber: 10001
 homeDirectory: /home/bobtest
 userPassword: test432bob
 loginShell: /bin/bash
@@ -22,9 +22,9 @@ mobile: 0469 000000
 description: A test user created by Alastair
 shadowExpire: -1
 
-dn: gidNumber=6969,ou=UPG,ou=Groups,dc=plug,dc=org,dc=au
-gidNumber: 6969
-member: uidNumber=6969,ou=Users,dc=plug,dc=org,dc=au
+dn: gidNumber=10001,ou=UPG,ou=Groups,dc=plug,dc=org,dc=au
+gidNumber: 10001
+member: uidNumber=10001,ou=Users,dc=plug,dc=org,dc=au
 objectClass: groupOfNames
 objectClass: posixGroup
 cn: bobtest
@@ -32,4 +32,4 @@ cn: bobtest
 dn: cn=currentmembers,ou=Groups,dc=plug,dc=org,dc=au
 changetype: modify
 add: member
-member: uidNumber=6969,ou=Users,dc=plug,dc=org,dc=au
+member: uidNumber=10001,ou=Users,dc=plug,dc=org,dc=au

--- a/ci/user-chair.ldif
+++ b/ci/user-chair.ldif
@@ -1,4 +1,4 @@
-dn: uidNumber=6000,ou=Users,dc=plug,dc=org,dc=au
+dn: uidNumber=10000,ou=Users,dc=plug,dc=org,dc=au
 objectClass: top
 objectClass: person
 objectClass: posixAccount
@@ -7,8 +7,8 @@ objectClass: shadowAccount
 objectClass: mailForwardingAccount
 uid: chair
 displayName: PLUG Chair
-uidNumber: 6000
-gidNumber: 6000
+uidNumber: 10000
+gidNumber: 10000
 homeDirectory: /home/chair
 userPassword: chairpass
 loginShell: /bin/bash
@@ -21,9 +21,9 @@ street: 42 Test Bvd, Nowheresville 6969
 mobile: 0469 000000
 shadowExpire: -1
 
-dn: gidNumber=6000,ou=UPG,ou=Groups,dc=plug,dc=org,dc=au
-gidNumber: 6000
-member: uidNumber=6000,ou=Users,dc=plug,dc=org,dc=au
+dn: gidNumber=10000,ou=UPG,ou=Groups,dc=plug,dc=org,dc=au
+gidNumber: 10000
+member: uidNumber=10000,ou=Users,dc=plug,dc=org,dc=au
 objectClass: groupOfNames
 objectClass: posixGroup
 cn: chair
@@ -31,10 +31,10 @@ cn: chair
 dn: cn=currentmembers,ou=Groups,dc=plug,dc=org,dc=au
 changetype: modify
 add: member
-member: uidNumber=6000,ou=Users,dc=plug,dc=org,dc=au
+member: uidNumber=10000,ou=Users,dc=plug,dc=org,dc=au
 
 
 dn: cn=committee,ou=Groups,dc=plug,dc=org,dc=au
 changetype: modify
 add: member
-member: uidNumber=6000,ou=Users,dc=plug,dc=org,dc=au
+member: uidNumber=10000,ou=Users,dc=plug,dc=org,dc=au

--- a/tests/UGMMTest.php
+++ b/tests/UGMMTest.php
@@ -73,7 +73,7 @@ final class UGMMTest extends TestCase {
         $this->assertText($rows->eq(0), 'th', 'Username');
         $this->assertText($rows->eq(0), 'td', 'bobtest');
         $this->assertText($rows->eq(1), 'th', 'Unix User ID');
-        $this->assertText($rows->eq(1), 'td', '6969');
+        $this->assertText($rows->eq(1), 'td', '10001');
         $this->assertText($rows->eq(2), 'th', 'Shell');
         $this->assertText($rows->eq(2), 'td', '/bin/bash');
         $this->assertText($rows->eq(3), 'th', 'Account expires');


### PR DESCRIPTION
The version I found seemed to be based on an earlier version of the draft. Crucially, it didn't include the ORDERING property on the `shadowExpire` attribute (added in draft-02). This prevented the `expiredmembers.php` script from finding expired memberships.
    
The replacement schema is an LDIF conversion of the following:
    
https://github.com/jtyr/rfc2307bis/blob/master/rfc2307bis.schema
    
The version being replaced also included a copy of the `namedobject` schema, which this one doesn't. So we need to add that one manually.
