### PR TITLE
Add support for sorting the member list with javascript

### DIFF
--- a/ci/ugmm-nginx.conf
+++ b/ci/ugmm-nginx.conf
@@ -24,6 +24,10 @@ server {
         return 302 /memberself;
     }
 
+    location ^~ /javascript {
+        alias /usr/share/javascript;
+    }
+
     location ~ \.(css|gif|png|ico)$ {
     }
 

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: http://www.plug.org.au/projects/ugmm/
 
 Package: plug-ugmm
 Architecture: all
-Depends: ${misc:Depends}, smarty4, php, nginx | apache2-bin, php-net-ldap2
+Depends: ${misc:Depends}, smarty4, php, nginx | apache2-bin, libjs-sortable-tablesort, php-net-ldap2
 Recommends: php-fpm
 Description: PLUG User Group Members Management
  PHP Frontend to LDAP backend for managing a user group of members

--- a/extras/examples/apache/plug-ugmm.conf
+++ b/extras/examples/apache/plug-ugmm.conf
@@ -13,3 +13,8 @@
         RewriteCond "%{REQUEST_FILENAME}" !-d
         RewriteRule (.*) $1.php [L]
     </Directory>
+
+    Alias /javascript /usr/share/javascript
+    <Directory /usr/share/javascript>
+        Require all granted
+    </Directory>

--- a/extras/examples/apache/plug-ugmm.section.conf
+++ b/extras/examples/apache/plug-ugmm.section.conf
@@ -9,3 +9,8 @@
         RewriteCond "%{REQUEST_FILENAME}" !-d
         RewriteRule (.*) $1.php [L]
     </Directory>
+
+    Alias /javascript /usr/share/javascript
+    <Directory /usr/share/javascript>
+        Require all granted
+    </Directory>

--- a/extras/examples/nginx/plug-ugmm.conf
+++ b/extras/examples/nginx/plug-ugmm.conf
@@ -12,6 +12,11 @@
         rewrite .* /memberself permanent;
     }
 
+    # Forced prefix for JavaScript files installed from system packages
+    location ^~ /javascript {
+        alias /usr/share/javascript;
+    }
+
     # Paths without an extension after the first component are handled by
     # PHP files
     location ~ ^/[^./]+(/|$) {

--- a/extras/examples/nginx/plug-ugmm.section.conf
+++ b/extras/examples/nginx/plug-ugmm.section.conf
@@ -7,6 +7,11 @@
         rewrite .* /ugmm/memberself permanent;
     }
 
+    # Forced prefix for JavaScript files installed from system packages
+    location ^~ /javascript {
+        alias /usr/share/javascript;
+    }
+
     # Paths without an extension after the first component are handled by
     # PHP files
     location ~ ^/ugmm/[^./]+(/|$) {

--- a/www/templates/listusers.tpl
+++ b/www/templates/listusers.tpl
@@ -1,10 +1,14 @@
 {extends file="base.tpl"}
 {block name=pagetitle} - Membership List{/block}
 {block name=title}Membership List{/block}
+{block name=head_extra}
+<link href="/javascript/sortable-tablesort/sortable-base.min.css" rel="stylesheet" />
+<script src="/javascript/sortable-tablesort/sortable.min.js"></script>
+{/block}
 {block name=body}
 
 {function member_table}
-<table class="membertable">
+<table class="membertable sortable asc">
   <thead>
     <tr>
       <th>ID</th>
@@ -25,7 +29,7 @@
       <td>{$user.displayName}</td>
       <td>{$user.mail}{if isset($user.mailForward) and $user.mailForward}<br/><strong>Fwd: {$user.mailForward}</strong>{/if}</td>
       <td>{foreach from=$user.groups item=group}{$group}<br/>{/foreach}</td>
-      <td>{if $user.expiry_raw > 1}{$user.expiry}{/if}</td>
+      <td data-sort="{$user.expiry_raw}">{if $user.expiry_raw > 1}{$user.expiry}{/if}</td>
       <td>{if $user.shellEnabled}T{/if}</td>
       <td><a href="{$submenuitems.ctte.editmember.link}{$user.uidNumber}">Edit</a></td>
     </tr>


### PR DESCRIPTION
This adds support for dynamically sorting the member list via [sortable.js](https://github.com/tofsjonas/sortable), which is now packaged in Debian 13.

Click on the table headers to sort that value in ascending or descending order. We annotate the expiry column with the numeric version so it doesn't sort them as strings.