### PR TITLE
Add a JS preview of the payment amount to the new payment form

### DIFF
--- a/lib/PLUG/Members.class.php
+++ b/lib/PLUG/Members.class.php
@@ -1101,6 +1101,21 @@ class Person
 
     public function makePayment(int $type, int $years, DateTimeImmutable $date, string $description, bool $ack, int|bool $id = false): int
     {
+        // Validate payment details
+        if ($type != FULL_TYPE && $type != CONCESSION_TYPE) {
+            $this->errors[] = "Invalid membership type";
+            return -1;
+        }
+        if ($years <= 0) {
+            $this->errors[] = "Invalid membership duration";
+            return -1;
+        }
+
+        if ($description === "") {
+            $this->errors[] = "Missing payment description";
+            return -1;
+        }
+
         $payment = Payment::create($this->ldap, $this->dn, $type, $years, $date, $description, $id);
 
         // If the payment date is before the expiry date, increase the expiry date.

--- a/lib/PLUG/pagefunctions.inc.php
+++ b/lib/PLUG/pagefunctions.inc.php
@@ -76,8 +76,8 @@ $smarty->assign('topmenuitems', $toplevelmenu);
 $smarty->assign('submenuitems', $submenu);
 
 // Membership amount
-$smarty->assign('CONCESSION_AMOUNT', "$" . CONCESSION_AMOUNT / 100);
-$smarty->assign('FULL_AMOUNT', "$" . FULL_AMOUNT / 100);
+$smarty->assign('CONCESSION_AMOUNT', CONCESSION_AMOUNT / 100);
+$smarty->assign('FULL_AMOUNT', FULL_AMOUNT / 100);
 
 // External links
 $smarty->assign('external_links', EXTERNAL_LINKS);

--- a/lib/PLUG/templates/editmember.tpl
+++ b/lib/PLUG/templates/editmember.tpl
@@ -76,7 +76,7 @@
 
     <label for="payment_date">Payment date</label>
     <div class="field">
-      <input type="date" name="payment_date" size="10"> (leave blank for "now")
+      <input type="date" name="payment_date" size="10"> (leave blank for "today")
     </div>
 
     <div class="label">Membership type</div>
@@ -87,7 +87,7 @@
 
     <label for="years">Duration</label>
     <div class="field">
-      <input type="number" name="years" value="1" size="2"> year(s)
+      <input type="number" name="years" value="1" min="1" size="2"> year(s)
     </div>
 
     <div class="label">Total</div>

--- a/lib/PLUG/templates/editmember.tpl
+++ b/lib/PLUG/templates/editmember.tpl
@@ -66,28 +66,69 @@
 
   <h3>Make Membership Payment</h3>
 
-  <form method="post" action="">
+  <form method="post" action="" id="payment_form" class="grid">
     <input type="hidden" name="payment_form" value="1">
     <input type="hidden" name="nonce" value="{'makepayment'|nonce}">
     <input type="hidden" name="id" value="{$member->uidNumber}">
-    Receive payment for
-    <label><input type="radio" name="membership_type" value="1" checked>Full ({$FULL_AMOUNT}/yr)</label>
-    <label><input type="radio" name="membership_type" value="2">Concession ({$CONCESSION_AMOUNT}/yr)</label>
-    for <input type="number" name="years" value="1" size="2"> year(s).<br>
 
-    Backdate this payment to
-    <input type="date" name="payment_date" size="10"> (leave blank for "now").<br>
+    <input type="hidden" name=".cgifields" value="payment_ack">
+    <input type="hidden" name=".cgifields" value="membership_type">
 
-    Receipt # (or comment) <input type="text" name="receipt_number" size="30"><br>
-    <input type="submit" name="go_go_button" value="Make Payment">
-    <label><input type="checkbox" name="payment_ack" value="1" checked>
-    E-mail acknowledgement to member</label><br>
+    <label for="payment_date">Payment date</label>
+    <div class="field">
+      <input type="date" name="payment_date" size="10"> (leave blank for "now")
+    </div>
 
-    <div>
-      <input type="hidden" name=".cgifields" value="payment_ack">
-      <input type="hidden" name=".cgifields" value="membership_type">
+    <div class="label">Membership type</div>
+    <div class="field">
+      <label><input type="radio" name="membership_type" value="1" checked>Full (${$FULL_AMOUNT}/yr)</label>
+      <label><input type="radio" name="membership_type" value="2">Concession (${$CONCESSION_AMOUNT}/yr)</label>
+    </div>
+
+    <label for="years">Duration</label>
+    <div class="field">
+      <input type="number" name="years" value="1" size="2"> year(s)
+    </div>
+
+    <div class="label">Total</div>
+    <div class="field">
+      <output id="payment_total"></output>
+    </div>
+
+    <label for="receipt_number">Receipt # (or comment)</label>
+    <div class="field">
+      <input type="text" name="receipt_number" size="30"><br>
+    </div>
+
+    <div class="label"></div>
+    <div class="field">
+      <label><input type="checkbox" name="payment_ack" value="1" checked>
+      E-mail acknowledgement to member</label>
+    </div>
+
+    <div class="actions">
+      <input type="submit" name="go_go_button" value="Make Payment">
     </div>
   </form>
+
+  <script type="text/javascript">
+      const FULL_AMOUNT = {$FULL_AMOUNT};
+      const CONCESSION_AMOUNT = {$CONCESSION_AMOUNT};
+      {literal}
+      const payment_form = document.getElementById('payment_form');
+      const update_payment_total = () => {
+          const formdata = new FormData(payment_form);
+          const membership_type = formdata.get('membership_type');
+          const years = formdata.get('years');
+          const payment_total = document.getElementById('payment_total');
+
+          const total = (membership_type == '2' ? CONCESSION_AMOUNT : FULL_AMOUNT) * years;
+          payment_total.innerHTML = '$' + total.toString();
+      };
+      payment_form.addEventListener('input', update_payment_total);
+      update_payment_total();
+      {/literal}
+  </script>
 
   <h4>Past Payments</h4>
 

--- a/lib/PLUG/templates/signup.tpl
+++ b/lib/PLUG/templates/signup.tpl
@@ -48,7 +48,7 @@ document.addEventListener('DOMContentLoaded', () => {
 If you would like to become a financial PLUG member, please fill in the following details. Becoming a member gives you the benefits listed at <a href="{$external_links.membership}">{$external_links.membership}</a>. You <strong>DO NOT</strong> need to be a member to access our <a href="{$external_links.lists}">mailing list</a> or to attend our normal <a href="{$external_links.events}">events</a>.
 </p>
 <p>
-Membership costs are {$FULL_AMOUNT} p.a., or {$CONCESSION_AMOUNT} p.a. for students / concession.
+Membership costs are ${$FULL_AMOUNT} p.a., or ${$CONCESSION_AMOUNT} p.a. for students / concession.
 </p>
 
   <form method="post" action="" class="grid">

--- a/lib/PLUG/templates/signupcompleted.tpl
+++ b/lib/PLUG/templates/signupcompleted.tpl
@@ -13,7 +13,7 @@ shell account will not be actived. However, the mailing list is still freely
 accessible to non-members.
 </p>
 <p>
-Membership costs are {$FULL_AMOUNT} p.a., or {$CONCESSION_AMOUNT} p.a. for students / concession.
+Membership costs are ${$FULL_AMOUNT} p.a., or ${$CONCESSION_AMOUNT} p.a. for students / concession.
 <p>
 
 <p>

--- a/tests/MembersTest.php
+++ b/tests/MembersTest.php
@@ -63,11 +63,11 @@ final class MembersTest extends TestCase
     {
         $member = $this->newMember();
 
-        $member->makePayment(FULL_TYPE, 1, new DateTimeImmutable('2025-11-15'), "", false);
+        $member->makePayment(FULL_TYPE, 1, new DateTimeImmutable('2025-11-15'), "description", false);
         $this->assertSame($member->expiry, '15 Nov 26');
 
         // Making a payment before the expiry date extends the old expiry
-        $member->makePayment(FULL_TYPE, 1, new DateTimeImmutable('2026-09-01'), "", false);
+        $member->makePayment(FULL_TYPE, 1, new DateTimeImmutable('2026-09-01'), "description", false);
         $this->assertSame($member->expiry, '15 Nov 27');
     }
 
@@ -75,11 +75,11 @@ final class MembersTest extends TestCase
     {
         $member = $this->newMember();
 
-        $member->makePayment(FULL_TYPE, 1, new DateTimeImmutable('2025-11-15'), "", false);
+        $member->makePayment(FULL_TYPE, 1, new DateTimeImmutable('2025-11-15'), "description", false);
         $this->assertSame($member->expiry, '15 Nov 26');
 
         // Making a payment after expiry, but within grace period extends expiry
-        $member->makePayment(FULL_TYPE, 1, new DateTimeImmutable('2026-12-25'), "", false);
+        $member->makePayment(FULL_TYPE, 1, new DateTimeImmutable('2026-12-25'), "description", false);
         $this->assertSame($member->expiry, '15 Nov 27');
     }
 
@@ -87,11 +87,11 @@ final class MembersTest extends TestCase
     {
         $member = $this->newMember();
 
-        $member->makePayment(FULL_TYPE, 1, new DateTimeImmutable('2025-11-15'), "", false);
+        $member->makePayment(FULL_TYPE, 1, new DateTimeImmutable('2025-11-15'), "description", false);
         $this->assertSame($member->expiry, '15 Nov 26');
 
         // Making a payment after grace period dates membership from payment date
-        $member->makePayment(FULL_TYPE, 1, new DateTimeImmutable('2027-03-14'), "", false);
+        $member->makePayment(FULL_TYPE, 1, new DateTimeImmutable('2027-03-14'), "description", false);
         $this->assertSame($member->expiry, '14 Mar 28');
     }
 
@@ -100,7 +100,37 @@ final class MembersTest extends TestCase
         $member = $this->newMember();
 
         // A payment will cover 366 days during a leap year
-        $member->makePayment(FULL_TYPE, 1, new DateTimeImmutable('2023-06-01'), "", false);
+        $member->makePayment(FULL_TYPE, 1, new DateTimeImmutable('2023-06-01'), "description", false);
         $this->assertSame($member->expiry, '01 Jun 24');
+    }
+
+    public function testMakePaymentInvalidType(): void
+    {
+        $member = $this->newMember();
+
+        // A payment with an invalid membership type
+        $member->makePayment(1000, 1, new DateTimeImmutable('2023-11-15'), "description", false);
+        $this->assertSame($member->is_error(), true);
+        $this->assertSame($member->get_errors(), ["Invalid membership type"]);
+    }
+
+    public function testMakePaymentInvalidDuration(): void
+    {
+        $member = $this->newMember();
+
+        // A payment with an invalid membership type
+        $member->makePayment(FULL_TYPE, -1, new DateTimeImmutable('2023-11-15'), "description", false);
+        $this->assertSame($member->is_error(), true);
+        $this->assertSame($member->get_errors(), ["Invalid membership duration"]);
+    }
+
+    public function testMakePaymentInvalidDescription(): void
+    {
+        $member = $this->newMember();
+
+        // A payment with an invalid membership type
+        $member->makePayment(FULL_TYPE, 1, new DateTimeImmutable('2023-11-15'), "", false);
+        $this->assertSame($member->is_error(), true);
+        $this->assertSame($member->get_errors(), ["Missing payment description"]);
     }
 }

--- a/www/style.css
+++ b/www/style.css
@@ -77,7 +77,7 @@ summary > h3 {
     row-gap: 0.25em;
 }
 
-.grid label, .grid .label {
+.grid > label, .grid > .label {
     display: block;
     font-weight: bold;
     text-align: right;


### PR DESCRIPTION
This is a clean-up for the payment form to use a more standard layout, and to show the amount the payment will be recorded as. Here is what the changed UI looks like:

<img width="763" height="360" alt="image" src="https://github.com/user-attachments/assets/dc0ab0c3-661e-414f-a481-79bb047e4bdc" />

The eventual goal is to let us record the payment with the actual dollar amount for when people provide additional donations, or if we grant a complementary membership (as described in #53). I'm not completely sure what the UI for that should look like though.